### PR TITLE
Update sync-to-gitlab.yml

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -40,7 +40,7 @@ jobs:
           # Only commit if there are changes
           if ! git diff --cached --quiet; then
             git commit -m "Sync changed files from GitHub"
-            git push https://oauth2:${GITLAB_TOKEN}@gitlab.tudelft.nl/opentextbooks/linear-algebra publish
+            git push https://oauth2:${GITLAB_TOKEN}@gitlab.tudelft.nl/opentextbooks/linear-algebra published:publish
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/sync-to-gitlab.yml` file. The change modifies the Git push command to specify the `published:publish` ref instead of just `publish`.