### PR TITLE
Clarify linear algebra documentation and correct notation errors

### DIFF
--- a/Chapter2/LinearSystems.md
+++ b/Chapter2/LinearSystems.md
@@ -1141,7 +1141,7 @@ If two augmented matrices are row equivalent it means that the linear systems th
 ::::
 
 Above we applied row operations to an augmented matrix, to work our way to the solution to a system of equations.
-In fact we simplified the system and the matrix along parallel paths. From now on we will simplify a system by working almost always with the corresponding augmented matrix.
+In fact we simplified the system and the matrix along parallel paths. From now on we will simplify a system by working almost exclusively with the corresponding augmented matrix.
 
 In later chapters we will also apply row reduction to matrices in other contexts, i.c. for other purposes.
 

--- a/Chapter2/MatrixVectorProduct.md
+++ b/Chapter2/MatrixVectorProduct.md
@@ -536,15 +536,15 @@ $$
           \end{array}   \right),
           \quad \mathbf{p} =
           \left(\begin{array}{c}
-            p_1 \\ p_2 \\ \vdots \\ p_n
+            p_1 \\ p_2 \\ \vdots \\ p_m
           \end{array}\right),
           \quad \mathbf{q} =
           \left(\begin{array}{c}
-            q_1 \\ q_2 \\ \vdots \\ q_n
+            q_1 \\ q_2 \\ \vdots \\ q_m
           \end{array}\right)
           \quad \mathbf{r} =
           \left(\begin{array}{c}
-            r_1 \\ r_2 \\ \vdots \\ r_n
+            r_1 \\ r_2 \\ \vdots \\ r_m
           \end{array}\right).
 $$
 

--- a/Chapter3/GeometryofLinearTransformations.md
+++ b/Chapter3/GeometryofLinearTransformations.md
@@ -355,7 +355,7 @@ The following proposition guarantees that, as you would expect, applying a refle
 ::::::{prf:proposition}
 :label: Prop:GeomLinTrans:TwoReflections
 
-If $M$ is the standard matrix of a reflection, then $R^{2}=I$.
+If $M$ is the standard matrix of a reflection, then $M^{2}=I$.
 
 ::::::
 

--- a/Chapter3/Linear_Transformations.md
+++ b/Chapter3/Linear_Transformations.md
@@ -724,7 +724,7 @@ $$
    S: \mathbb{R}^n \to \mathbb{R}^m, \quad S(\mathbf{x}) = T_1(\mathbf{x}) + T_2(\mathbf{x}).
 $$
 
-And the (scalar) multiple $T_3 = cT_1$ is the transformation
+The (scalar) multiple $T_3 = cT_1$ is the transformation
 
 $$
   T_3: \mathbb{R}^n \to \mathbb{R}^m, \quad T_3(\mathbf{x}) = cT_1(\mathbf{x}).

--- a/Chapter4/BasisAndDimension.md
+++ b/Chapter4/BasisAndDimension.md
@@ -1037,7 +1037,7 @@ Because of {prf:ref}`Thm:BasisDim:EqualDim` this is a good definition.
 For the trivial subspace $S = \lbrace\vect{0}\rbrace$ we postulated that its basis is the empty set. Thus,
 
 $$
-\operatorname{dim} S = \operatorname{dim}(\emptyset) = 0.
+\operatorname{dim} S = \operatorname{dim}(\lbrace\vect{0}\rbrace) = 0.
 $$
 
 For the other trivial subspace, the whole $\R^n$, the standard basis
@@ -1706,7 +1706,7 @@ The statements in {prf:ref}`Thm:BasisDim:RankThm` are both reformulations of ear
 
 <li>
 
-{prf:ref}`Thm:MatrixInv:InvertibilityCharacterizations`.
+{prf:ref}`Thm:MatrixInv:InvertibilityCharacterizations` (1. $\iff$ 5.).
 
 </li>
 

--- a/Chapter6/CharPolynomial.md
+++ b/Chapter6/CharPolynomial.md
@@ -126,7 +126,7 @@ Note that this includes diagonal matrices $D$.
 
 For the $2\times 2$-matrix in {prf:ref}`Ex:EigenValues:FirstCharPoly` the expression $\det(A - \lambda I)$ eventually comes down to a polynomial of degree $2$.
 
-For an arbitrary $2 \times 2$-matrix $A = \begin{pmatrix} a-\lambda & b \\ c & d-\lambda \end{pmatrix}$ we quickly see that
+For an arbitrary $2 \times 2$-matrix $A = \begin{pmatrix} a & b \\ c & d \end{pmatrix}$ we quickly see that
 
 $$
 \operatorname{det}(A - \lambda I) = \begin{vmatrix} a-\lambda & b \\ c & d-\lambda \end{vmatrix} =

--- a/Chapter7/GramSchmidt.md
+++ b/Chapter7/GramSchmidt.md
@@ -98,7 +98,7 @@ The above construction/algorithm is called the **Gram-Schmidt process**.
 ::::{prf:example}
 :label: Ex:GramSchmidt:Orthogonalize
 
-Let $W$ be the defined as the span of the set $\left\{\begin{pmatrix} 1 \\ 1   \\ -1 \\ 1    \end{pmatrix}, \begin{pmatrix} 3 \\ 3   \\ -2 \\ 0    \end{pmatrix}, \begin{pmatrix} 3 \\ 1   \\ 4 \\ -4    \end{pmatrix}  \right\}$. It can be shown that these vectors are linearly independent.
+Let $W$ be defined as the span of the set $\left\{\begin{pmatrix} 1 \\ 1   \\ -1 \\ 1    \end{pmatrix}, \begin{pmatrix} 3 \\ 3   \\ -2 \\ 0    \end{pmatrix}, \begin{pmatrix} 3 \\ 1   \\ 4 \\ -4    \end{pmatrix}  \right\}$. It can be shown that these vectors are linearly independent.
 
 We use the Gram-Schmidt algorithm to create an orthogonal basis for $W$.
 
@@ -209,15 +209,15 @@ a subspace $W = \operatorname{Span}\{\vect{a}_1, \ldots, \vect{a}_m\}$ where the
 ::::{prf:example}
 :label: Ex:GramSchmidt:NonOrthog
 
-Let $W$ be the defined as the span of the set $\left\{\begin{pmatrix} 1 \\ -1   \\ 2 \\ 3    \end{pmatrix}, \begin{pmatrix} 2 \\ -2   \\ 4 \\ 6    \end{pmatrix}, \begin{pmatrix} 2 \\ 0   \\ 1 \\  2    \end{pmatrix}, \begin{pmatrix} 0 \\ 2  \\ -3 \\  -4    \end{pmatrix} \right\}$.
+Let $W$ be defined as the span of the set $\left\{\begin{pmatrix} 1 \\ -1   \\ 2 \\ 3    \end{pmatrix}, \begin{pmatrix} 2 \\ -2   \\ 4 \\ 6    \end{pmatrix}, \begin{pmatrix} 2 \\ 0   \\ 1 \\  2    \end{pmatrix}, \begin{pmatrix} 0 \\ 2  \\ -3 \\  -4    \end{pmatrix} \right\}$.
 
 Let us denote the vectors by $\vect{a}_1, \ldots, \vect{a}_4$. As in the proof of the Gram-Schmidt process
 we use the notation $W_j$ for the span of the vectors $ \vect{a}_1, \ldots, \vect{a}_j$.
 
 Just following the protocol we find
 
-$
-$\vect{b}_1 = \vect{a}_1 = \begin{pmatrix} 1 \\ -1   \\ 2 \\ 3    \end{pmatrix},  \quad
+$$
+\vect{b}_1 = \vect{a}_1 = \begin{pmatrix} 1 \\ -1   \\ 2 \\ 3    \end{pmatrix},  \quad
       \vect{b}_2 =   \vect{a}_{2} - \dfrac{\vect{a}_{2}\ip\vect{b}_1}{\vect{b}_1\ip\vect{b}_1}\vect{b}_1        = \begin{pmatrix} 0 \\ 0   \\ 0 \\ 0    \end{pmatrix}.
 $$
 

--- a/Chapter7/LeastSquares.md
+++ b/Chapter7/LeastSquares.md
@@ -18,7 +18,7 @@ There are different ways to define what is the _best_ line. For instance, we may
 Or, we can take the line for which the sum of vertical distances from the points to the line, i.e.,
 
 $$
-  S = \sum_{i=1}^{n} |y_i - (a + bx_i)|
+  S = \sum_{i=1}^{n} |y_i - (ax_i + b)|
 $$
 
 is minimal. This approach makes sense in a physicial context where typically the $x$-variable may be an input variable over which a researcher has control, and $y$ is some output variable which may be liable to fluctuations and/or uncertainties.
@@ -61,7 +61,7 @@ will be satisfied simultaneously. This only happens if the matrix-vector equatio
 :label: Eq:LeastSquares:Linefit
 
 \left(\begin{array}{cc}
-1 & x_1 \\ 1 & x_2 \\ \vdots & \vdots \\ 1 & x_n
+x_1 & 1 \\ x_2 & 1 \\ \vdots & \vdots \\ x_n & 1
 \end{array}\right)
 \left(\begin{array}{c}
 a \\ b
@@ -77,7 +77,7 @@ We will come back to this question in {numref}`Subsection %s <SubSec:LeastSquare
 
 (SubSec:LeastSquares:LS-solutions)=
 
-## least-squares solutions
+## Least-squares solutions
 
 Let $A$ be an $m \times n$-matrix with columns $\vect{a}_1, \ldots, \vect{a}_n$.
 
@@ -90,7 +90,7 @@ $$
 is equivalent to the vector equation
 
 $$
-  x_1\vect{a}_1 + \cdots + x_1\vect{a}_n = \vect{b}.
+  x_1\vect{a}_1 + \cdots + x_n\vect{a}_n = \vect{b}.
 $$
 
 What we can do if the linear system is inconsistent, thus if
@@ -186,7 +186,7 @@ In the situation where we want to fit a line $y = ax + b$, we can take as 'best'
 
 $$
   \left(\begin{array}{cc}
-        1 & x_1 \\ 1 & x_2 \\ \vdots & \vdots \\ 1 & x_n
+        x_1 & 1 \\ x_2 & 1 \\ \vdots & \vdots \\ x_n & 1
        \end{array}\right)
        \left(\begin{array}{c}
         a \\ b
@@ -200,7 +200,7 @@ The interpretation of the 'error vector' $A\vect{x} - \vect{b}$ then becomes
 
 $$
    \left(\begin{array}{c}
-        a+bx_1 - y_1 \\ a+bx_2 - y_2 \\ \vdots  \\ a+bx_n - y_n
+        ax_1+b - y_1 \\ ax_2+b - y_2 \\ \vdots  \\ ax_n+b - y_n
        \end{array}\right)
 $$
 
@@ -255,7 +255,7 @@ For each linear system $A\vect{x} = \vect{b}$, where $A$ is an $m \times n$-matr
 
 In {prf:ref}`Rem:LeastSquares:BestLinComb` it was noted that a least-squares solution corresponds to the vector in $\operatorname{Col}A$ that is closest to $\vect{b}$.
 
-The vector in $\operatorname{Col}A$ that is closest to $\vect{b}$ is precisely the orthogonal projection of $\vect{x}$ onto $\operatorname{Col}A$. (See {prf:ref}`Prop:Orthogonality:BestApprox`.)
+The vector in $\operatorname{Col}A$ that is closest to $\vect{b}$ is precisely the orthogonal projection of $\vect{b}$ onto $\operatorname{Col}A$. (See {prf:ref}`Prop:Orthogonality:BestApprox`.)
 
 This projection, a linear combination of the colums of $A$, always exists.
 
@@ -1111,12 +1111,12 @@ $$
 ## Linear models
 
 In {numref}`Subsection %s <SubSec:LeastSquares:Introduction>` we looked at ways to fit a line
-$y = a + bx$ to a set of points $(x_i, y_i), i = 1, \ldots, n$ in the plane. In statistics this plays an important role in so-called _regression models_.
+$y = ax + b$ to a set of points $(x_i, y_i), i = 1, \ldots, n$ in the plane. In statistics this plays an important role in so-called _regression models_.
 
-One way to define the best fitting line $y = \hat{a}+\hat{b}x$ is to let $(\hat{a},\hat{b})$ be the least-squares solution to the set of $n$ linear equations
+One way to define the best fitting line $y = \hat{a}x+\hat{b}$ is to let $(\hat{a},\hat{b})$ be the least-squares solution to the set of $n$ linear equations
 
 $$
-  y_i = a+bx_i, \quad  i = 1, \ldots , n.
+  y_i = ax_i + b, \quad  i = 1, \ldots , n.
 $$
 
 Note that in these equations the parameters $a$ and $b$ are the unknowns.
@@ -1164,7 +1164,7 @@ To find the least-squares line we consider the four equations in the form
 
 $$
    \left(\begin{array}{cc}
-         1 & x_1  \\ 1 &  x_2 \\ 1 &  x_3 \\ 1 &  x_4
+         x_1 & 1  \\ x_2 & 1 \\ x_3 & 1 \\ x_4 & 1
        \end{array}\right)
        \left(\begin{array}{c}  a \\ b \end{array}\right)
    = \left(\begin{array}{c}
@@ -1172,7 +1172,7 @@ $$
        \end{array}\right), \quad
        \,\, \text{i.e.,} \,\,
      \left(\begin{array}{cc}
-         1 & 1  \\ 1 &  2 \\ 1 &  4 \\ 1 &  5
+         1 & 1  \\ 2 &  1 \\ 4 &  1 \\ 5 &  1
        \end{array}\right)
        \left(\begin{array}{c}  a \\ b \end{array}\right)
    = \left(\begin{array}{c}
@@ -1185,13 +1185,13 @@ Since the matrix has linearly independent columns the normal equations, with aug
 $$
   \left(\,A^TA \,\middle| \,A^T \vect{b}\,\right) =
     \left(\begin{array}{cc|c}
-        4 &   12 &   10 \\
-        12 &   46 &   33
+        46 &   12 &   33 \\
+        12 &   4 &   10
        \end{array}
   \right),
 $$
 
-give a unique least-squares solution, and it is $\hat{a} = 1.6$, $\hat{b} = 0.3$.
+give a unique least-squares solution, and it is $\hat{a} = 0.3$, $\hat{b} = 1.6$.
 
 {numref}`Figure %s <Fig:LeastSquares:LSline>` shows both lines.
 
@@ -1199,14 +1199,14 @@ give a unique least-squares solution, and it is $\hat{a} = 1.6$, $\hat{b} = 0.3$
 :name: Fig:LeastSquares:LSline
 :class: dark-light
 
-least-squares line.
+Least-squares line.
 
 :::
 
-For the line $y = \hat{a}  + \hat{b}x$ the sum of the squares of the residues becomes
+For the line $y = \hat{a}x  + \hat{b}$ the sum of the squares of the residues becomes
 
 $$
-   (2 - (1.6+0.3\cdot1))^2 + (2 - (1.6+0.3\cdot2))^2 + (3 - (1.6+0.3\cdot4))^2 + (3 - (1.6+0.3\cdot5))^2 = 0.1^2 + 0.2^2 + 0.2^2 + 0.1^2 = 0.1.
+   (2 - (0.3\cdot1 + 1.6))^2 + (2 - (0.3\cdot2 + 1.6))^2 + (3 - (0.3\cdot4 + 1.6))^2 + (3 - (0.3\cdot5 + 1.6))^2 = 0.1^2 + 0.2^2 + 0.2^2 + 0.1^2 = 0.1.
 $$
 
 This is indeed slightly better than with the line found 'at first sight', where the sum was equal to $0.125$.
@@ -1218,13 +1218,13 @@ $(x_1,y_1), (x_2, y_2), \ldots, (x_n, y_n)$.
 ::::{prf:example}
 :label: Ex:LeastSquares:LineFit2
 
-The coefficients of the least-squares line $y = \hat{a}  + \hat{b}x$ for the set of points
+The coefficients of the least-squares line $y = \hat{a}x  + \hat{b$ for the set of points
 $(x_1,y_1), (x_2, y_2), \ldots, (x_n, y_n)$ are given by
 
 $$
   \begin{array}{ccl}
-  \hat{a} &=& \dfrac{(\sum x_i^2)(\sum y_i) -(\sum x_i)(\sum x_iy_i) }{n\sum x_i^2 - (\sum x_i)^2}, \\
-  \hat{b} &=& \dfrac{n(\sum x_iy_i) -(\sum x_i)(\sum y_i) }{n\sum x_i^2 - (\sum x_i)^2}.
+  \hat{a} &=& \dfrac{n(\sum x_iy_i) -(\sum x_i)(\sum y_i) }{n\sum x_i^2 - (\sum x_i)^2}, \\
+  \hat{b} &=& \dfrac{(\sum x_i^2)(\sum y_i) -(\sum x_i)(\sum x_iy_i) }{n\sum x_i^2 - (\sum x_i)^2}.
   \end{array}
 $$
 
@@ -1242,9 +1242,9 @@ the coefficients get the following more concise form,
 :::{math}
 :label: Eq:Leastquares:GeneralLinefit
 
-\hat{a} = \dfrac{\Sigma_{xx}\Sigma_y - \Sigma_x\Sigma_{xy}}{n\Sigma_{xx} - \Sigma_x^2},
+\hat{a} = \dfrac{n\Sigma_{xy} - \Sigma_x\Sigma_{y}}{n\Sigma_{xx} - \Sigma_x^2},
 \quad
-\hat{b} = \dfrac{n\Sigma_{xy} - \Sigma_x\Sigma_{y}}{n\Sigma_{xx} - \Sigma_x^2}.
+\hat{b} = \dfrac{\Sigma_{xx}\Sigma_y - \Sigma_x\Sigma_{xy}}{n\Sigma_{xx} - \Sigma_x^2}.
 
 :::
 
@@ -1254,10 +1254,10 @@ In matrix-vector form the linear system we want to solve reads
 
 $$
   \left(\begin{array}{cccc}
-         1 & x_1 \\
-         1 & x_2 \\
+         x_1 & 1 \\
+         x_2 & 1 \\
             \vdots   & \vdots \\
-         1 & x_n     \end{array}\right)
+         x_n & 1     \end{array}\right)
         \left(\begin{array}{c}
           a \\ b   \end{array}\right) =
         \left(\begin{array}{c}
@@ -1268,64 +1268,64 @@ Noting that
 
 $$
 \left(\begin{array}{cc}
-         1 & x_1 \\
-         1 & x_2 \\
+         x_1 & 1 \\
+         x_2 & 1 \\
             \vdots   & \vdots \\
-         1 & x_n     \end{array}\right)^T
+         x_n & 1     \end{array}\right)^T
          \left(\begin{array}{cc}
-         1 & x_1 \\
-         1 & x_2 \\
+         x_1 & 1 \\
+         x_2 & 1 \\
             \vdots   & \vdots \\
-         1 & x_n     \end{array}\right)
+         x_n & 1     \end{array}\right)
 =
 \left(\begin{array}{cc}
-         n & \sum x_i \\
-         \sum x_i & \sum x_i^2     \end{array}\right)
+         \sum x_i^2 & \sum x_i \\
+         \sum x_i & n     \end{array}\right)
 =
 \left(\begin{array}{cc}
-         n & \Sigma_x \\
-         \Sigma_x & \Sigma_{xx}     \end{array}\right)
+         \Sigma_{xx} & \Sigma_x \\
+         \Sigma_x & n     \end{array}\right)
 $$
 
 and
 
 $$
    \left(\begin{array}{cc}
-         1 & x_1 \\
-         1 & x_2 \\
+         x_1 & 1 \\
+         x_2 & 1 \\
             \vdots   & \vdots \\
-         1 & x_n     \end{array}\right)^T
+         x_n & 1     \end{array}\right)^T
     \left(\begin{array}{c}
           y_1 \\ y_2 \\   \vdots   \\ y_n  \end{array}\right)
     =
     \left(\begin{array}{c}
-          \sum y_i \\ \sum x_iy_i  \end{array}\right)
+          \sum x_iy_i \\ \sum y_i  \end{array}\right)
     =
    \left(\begin{array}{c}
-          \Sigma_y \\ \Sigma_{xy}  \end{array}\right).
+          \Sigma_{xy} \\ \Sigma_y  \end{array}\right).
 $$
 
 This leads to the normal equations
 
 $$
   \left(\begin{array}{cc}
-         n & \Sigma_x \\
-         \Sigma_x & \Sigma_{xx}     \end{array}\right)
+         \Sigma_{xx} & \Sigma_x \\
+         \Sigma_x & n     \end{array}\right)
            \left(\begin{array}{c}
           a\\ b  \end{array}\right)
   =  \left(\begin{array}{c}
-          \Sigma_y \\ \Sigma_{xy}  \end{array}\right).
+          \Sigma_{xy} \\ \Sigma_y  \end{array}\right).
 $$
 
 If we multiply both sides of this equation by
 
 $$
   \left(\begin{array}{cc}
-         n & \Sigma_x \\
-         \Sigma_x & \Sigma_{xx}     \end{array}\right) ^{-1} =
+         \Sigma_{xx} & \Sigma_x \\
+         \Sigma_x & n     \end{array}\right) ^{-1} =
     \dfrac{1}{n\Sigma_{xx} - \Sigma_x^2}  \left(\begin{array}{cc}
-         \Sigma_{xx}  & -\Sigma_x \\
-         -\Sigma_x &   n  \end{array}\right),
+         n  & -\Sigma_x \\
+         -\Sigma_x &   \Sigma_{xx}  \end{array}\right),
 $$
 
 we see the expressions in Equation {eq}`Eq:Leastquares:GeneralLinefit` readily appearing.

--- a/Chapter8/QuadraticForms.md
+++ b/Chapter8/QuadraticForms.md
@@ -1280,7 +1280,7 @@ We have to look at the solutions $\begin{pmatrix} x_1 \\ x_2 \end{pmatrix}$ of t
 We can rewrite the equation as
 
 $$
-\vect{x} ^TA\vect{x} =  \vect{0},\text{ with }\vect{x}=\begin{pmatrix} x_1 & x_2   \end{pmatrix}\text{ and }A=\begin{pmatrix} a & b \\ b & c   \end{pmatrix}.
+\vect{x} ^TA\vect{x} =  \vect{0},\text{ with }\vect{x}=\begin{pmatrix} x_1 \\ x_2   \end{pmatrix}\text{ and }A=\begin{pmatrix} a & b \\ b & c   \end{pmatrix}.
 $$
 
 As $A$ is symmetric, it can be orthogonally diagonalised as $A=QDQ^T$, with $D$ a diagonal matrix with the eigenvalues $\lambda_1, \lambda_2$ of $A$ on the diagonal and $Q$ an orthogonal matrix with the corresponding eigenvectors as columns.

--- a/Chapter8/SingularValueDecomp.md
+++ b/Chapter8/SingularValueDecomp.md
@@ -512,10 +512,10 @@ $$0\le \norm{A\vect{u}}^2 = \mathbf{u}^TA^TA\mathbf{u} = \mathbf{u}^T\lambda \ma
 
 Since $\mathbf{u}\ne \mathbf{0}$,  so $\norm{\mathbf{u}}\ne 0$  as well,  it follows that $\lambda \ge 0$.
 
-\item Let $\lambda$ be a non-zero eigenvalue of $A^TA$ with associated eigenvector $\mathbf{u}$. We have tp show that $\lambda$ is also an eigenvalue of $AA^T$. By the definition of eigenvalue we have $A^TA\mathbf{u} = \lambda\mathbf{u}$. 
+\item Let $\lambda$ be a non-zero eigenvalue of $A^TA$ with associated eigenvector $\mathbf{u}$. We have to show that $\lambda$ is also an eigenvalue of $AA^T$. By the definition of eigenvalue we have $A^TA\mathbf{u} = \lambda\mathbf{u}$. 
 Observe that if $A\mathbf{u}=\mathbf{0}$ then $\lambda\mathbf{u} = A^TA\mathbf{u} = \mathbf{0}$, which would imply that $\lambda =0$, which contradicts the hypothesis of $\lambda \ne 0$.
 
-Next, multiplying by $A$ on both sides of the previous identity we obtain
+Next, multiplying by $A$ on both sides of the identity $A^TA\mathbf{u} = \lambda\mathbf{u}$ we obtain
 
 $$
  AA^TA\mathbf{u} = (AA^T)A\mathbf{u}  = \lambda A\mathbf{u}, \quad \text{where} \quad A\mathbf{u}\ne \mathbf{0}.
@@ -527,7 +527,7 @@ Therefore,  $A\mathbf{u}$ is an eigenvector of $AA^T$ with associated eigenvalue
 To prove the converse, one can use a similar argument.
 
 
-Now let's have a look at the multiplicities.   Since $A^TA$ is symmetric, hence diagonalisable, for each eigenvalue $\lambda$, the geometric and algebraic multiplicity are equal. And the same holds, of course, for the matrix $AA^T$.  So we are done if we can show that for each eigenvalue $\lambda_i \neq 0$,
+Now let's have a look at the multiplicities. Since $A^TA$ is symmetric, hence diagonalisable, for each eigenvalue $\lambda$, the geometric and algebraic multiplicity are equal. And the same holds, of course, for the matrix $AA^T$.  So we are done if we can show that for each eigenvalue $\lambda_i \neq 0$,
 
 $$
     \operatorname{g.m.}_{A^TA}(\lambda_i) = \operatorname{g.m.}_{AA^T}(\lambda_i) 
@@ -557,7 +557,7 @@ $$
  c_1 = c_2   = \cdots = c_g =  0,
 $$
 
-which shows that the vectors $A\mathbf{v}_1, \ldots, A\mathbf{v}_g$ are $g$ *linearly independent* eigenvectors  (of $AA^T$).  So the geometric multiplicity $g_2$ of $\lambda_i$ for $AA^T$
+which shows that the vectors $A\mathbf{v}_1, \ldots, A\mathbf{v}_g$ are *linearly independent* eigenvectors  (of $AA^T$).  So the geometric multiplicity $g_2$ of $\lambda_i$ for $AA^T$
 is at least as large as the geometric multiplicity $g$ of $\lambda_i$ for $A^TA$.
 Again, by the inherent symmetry the argument can be reversed, and we find that the geometric multiplicity of $\lambda_i$  is the same for $A^TA$ as for $AA^T$. 
 :::

--- a/Chapter9/DynSystContinuous.md
+++ b/Chapter9/DynSystContinuous.md
@@ -298,7 +298,7 @@ If $A$ is a diagonalisable matrix with eigenvalues $\lambda_{1},\ldots,\lambda_{
 
 $$
 
-\vect{y}(t)=c_{1}\vect{v}_{1}e^{\lambda{1}t}+c_{2}\vect{v}_{2}e^{\lambda_{2}t}+\cdots+c_{n}\vect{v}_{n}e^{\lambda_{n}t},
+\vect{y}(t)=c_{1}\vect{v}_{1}e^{\lambda_{1}t}+c_{2}\vect{v}_{2}e^{\lambda_{2}t}+\cdots+c_{n}\vect{v}_{n}e^{\lambda_{n}t},
 
 $$
 

--- a/Chapter9/DynSystDiscrete.md
+++ b/Chapter9/DynSystDiscrete.md
@@ -9,7 +9,7 @@ In this section we will assume the reader is familiar with complex numbers and t
 
 ## Introduction
 
-In this section we will consider linear transformations $T: \R^n \to \R^n$ from another perpective. We will follow the 'paths' of vectors under repeated application of $T$. In case $T$ is represented by the matrix $A$ this means we will study the sequence
+In this section we will consider linear transformations $T: \R^n \to \R^n$ from another perspective. We will follow the 'paths' of vectors under repeated application of $T$. In case $T$ is represented by the matrix $A$ this means we will study the sequence
 
 $$
    \vect{x}_0,\,\, \vect{x}_1=A\vect{x}_0,\,\,\vect{x}_2= A\vect{x}_1,\,\,\vect{x}_3= A\vect{x}_2,\,\,\ldots

--- a/Chapter9/PowerMethod.md
+++ b/Chapter9/PowerMethod.md
@@ -796,7 +796,7 @@ The process will never come to a standstill.
 What we can say is that eventually all vectors $\vect{x}_k$  will be in the span of the two complex eigenvectors
 
 $$
-  \vect{v}_1 = \begin{pmatrix}0\\2\\i \end{pmatrix}, \quad \vect{v}_1 = \begin{pmatrix}0\\2\\-i \end{pmatrix}.
+  \vect{v}_1 = \begin{pmatrix}0\\2\\i \end{pmatrix}, \quad \vect{v}_2 = \begin{pmatrix}0\\2\\-i \end{pmatrix}.
 $$
 
 These vectors, being linearly independent, span the set


### PR DESCRIPTION
This pull request makes a series of corrections and clarifications across several chapters, with a focus on fixing errors and improving the consistency of the least-squares regression section in Chapter 7. The most important changes include correcting the formulation of the least-squares line, fixing matrix and formula errors, and clarifying definitions and notation. Additional minor corrections address typos, mathematical inaccuracies, and language improvements throughout the text.

**Minor corrections to least-squares regression (Chapter 7):**

* Corrected the formula for the regression line from $y = a + bx$ to $y = ax + b$ throughout the text, including equations, matrix representations, and explanations. This includes updating the order of coefficients in matrices and formulas, and ensuring the solution expressions for $\hat{a}$ and $\hat{b}$ are correct and consistent. [[1]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL21-R21) [[2]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL64-R64) [[3]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL189-R189) [[4]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL203-R203) [[5]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1114-R1119) [[6]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1167-R1175) [[7]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1188-R1209) [[8]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1221-R1227) [[9]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1245-R1247) [[10]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1257-R1260) [[11]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1271-R1328)
* Fixed errors in the matrix normal equations and their solutions, including the correct calculation of sums and the placement of $x_i$ and $y_i$ terms. [[1]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1188-R1209) [[2]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1245-R1247) [[3]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1271-R1328)
* Corrected the formula for the sum of squared errors and the interpretation of the error vector in the context of least-squares. [[1]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL203-R203) [[2]](diffhunk://#diff-361e86e253c1e7140b79dfa3fe7e549489dd1a12c6e7def5e1f443ef80fffb7aL1188-R1209)
* Fixed the definition of the orthogonal projection in the context of least-squares solutions, changing "projection of $\vect{x}$" to "projection of $\vect{b}$".

**General mathematical and language corrections:**

* Fixed a mathematical typo in the definition of the dimension of the trivial subspace, changing $\operatorname{dim}(\emptyset)$ to $\operatorname{dim}(\lbrace\vect{0}\rbrace)$.
* Corrected the standard matrix notation in a proposition about reflections from $R^2 = I$ to $M^2 = I$.
* Fixed vector and matrix dimension errors in matrix-vector product examples, changing $n$ to $m$ where appropriate.
* Improved clarity and accuracy in several examples, including fixing the definition of the span in Gram-Schmidt examples and correcting display math formatting. [[1]](diffhunk://#diff-868f23bb37ed8fc2851b4817179d17551fbeb4b6f19c670bc908c78e985ee528L101-R101) [[2]](diffhunk://#diff-868f23bb37ed8fc2851b4817179d17551fbeb4b6f19c670bc908c78e985ee528L212-R220)
* Addressed minor language issues, such as changing "almost always" to "almost exclusively" and correcting typos like "tp show" to "to show". [[1]](diffhunk://#diff-bdcb9eb9b50fe6567a8954cc04dd8e540ace52426c9363b19ae87f0b64c2a01aL1144-R1144) [[2]](diffhunk://#diff-505fe74cbd1430cf1cc48e657849f9c87c08da6a4fcc4f3dba79d8607abeb7caL515-R518)
* Fixed vector notation and matrix dimensions in quadratic forms and other mathematical contexts.

These changes improve the mathematical accuracy, clarity, and consistency of the text across multiple chapters.